### PR TITLE
Add scroll utilities and back to top

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -899,3 +899,21 @@
       padding: 1.5rem;
     }
   }
+
+/* Back to Top Button */
+#back-to-top {
+  position: fixed;
+  bottom: 40px;
+  right: 40px;
+  display: none;
+  background: #22c55e;
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 48px;
+  height: 48px;
+  font-size: 1.5rem;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+  z-index: 9999;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,45 @@
+// Main site-wide JavaScript utilities
+
+// Smooth scrolling for anchor links
+export function initSmoothScroll() {
+  document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+    anchor.addEventListener('click', function(e) {
+      const targetSelector = this.getAttribute('href');
+      const target = document.querySelector(targetSelector);
+      if (target) {
+        e.preventDefault();
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    });
+  });
+}
+
+// Back to top button functionality
+export function initBackToTop() {
+  const button = document.getElementById('back-to-top');
+  if (!button) return;
+  window.addEventListener('scroll', () => {
+    if (window.scrollY > 300) {
+      button.style.display = 'block';
+    } else {
+      button.style.display = 'none';
+    }
+  });
+  button.addEventListener('click', e => {
+    e.preventDefault();
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  });
+}
+
+// Initialize features when DOM is ready
+export function initSiteFeatures() {
+  initSmoothScroll();
+  initBackToTop();
+  console.log('Site features initialized');
+}
+
+if (document.readyState !== 'loading') {
+  initSiteFeatures();
+} else {
+  document.addEventListener('DOMContentLoaded', initSiteFeatures);
+}

--- a/index.html
+++ b/index.html
@@ -1612,22 +1612,6 @@
             });
           });
       });
-
-      // Smooth scrolling for anchor links
-      document.addEventListener("DOMContentLoaded", function () {
-        document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
-          anchor.addEventListener("click", function (e) {
-            e.preventDefault();
-            const target = document.querySelector(this.getAttribute("href"));
-            if (target) {
-              target.scrollIntoView({
-                behavior: "smooth",
-                block: "start",
-              });
-            }
-          });
-        });
-      });
     </script>
 
     <!-- OpenWidget noscript fallback -->
@@ -1646,5 +1630,7 @@
         >OpenWidget</a
       ></noscript
     >
+    <button id="back-to-top" aria-label="Back to top">↑</button>
+    <script type="module" src="assets/js/main.js"></script>
   </body>
 </html>

--- a/public/about.html
+++ b/public/about.html
@@ -667,5 +667,7 @@
     });
 </script>
 
+<button id="back-to-top" aria-label="Back to top">↑</button>
+<script type="module" src="assets/js/main.js"></script>
 </body>
 </html>

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -175,3 +175,21 @@ footer {
     margin-top: 2rem;
   }
 }
+
+/* Back to Top Button */
+#back-to-top {
+  position: fixed;
+  bottom: 40px;
+  right: 40px;
+  display: none;
+  background: #1e3c72;
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 48px;
+  height: 48px;
+  font-size: 1.5rem;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+  z-index: 9999;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -256,5 +256,7 @@
         >OpenWidget</a
       ></noscript
     >
+  <button id="back-to-top" aria-label="Back to top">↑</button>
+  <script type="module" src="assets/js/main.js"></script>
   </body>
 </html>

--- a/public/inquiry.html
+++ b/public/inquiry.html
@@ -69,5 +69,7 @@
         'page_location': window.location.href
     });
 </script>
+<button id="back-to-top" aria-label="Back to top">↑</button>
+<script type="module" src="assets/js/main.js"></script>
 </body>
 </html>

--- a/public/landing.html
+++ b/public/landing.html
@@ -50,5 +50,7 @@
         'page_location': window.location.href
     });
 </script>
+<button id="back-to-top" aria-label="Back to top">↑</button>
+<script type="module" src="assets/js/main.js"></script>
 </body>
 </html>

--- a/public/modern.html
+++ b/public/modern.html
@@ -339,5 +339,7 @@
         document.addEventListener('keydown',function(e){if(e.key==='Escape'){closeForm();const navLinks=document.querySelector('.nav-links');if(navLinks.style.display==='flex'){toggleMenu();}}});
         document.addEventListener('DOMContentLoaded',function(){document.querySelectorAll('.fade-in').forEach(el=>{observer.observe(el);});document.querySelectorAll('.feature-card').forEach((card,index)=>{card.style.transitionDelay=`${index*0.1}s`;});document.querySelectorAll('.trust-card').forEach((card,index)=>{card.style.transitionDelay=`${index*0.1}s`;});});
     </script>
+<button id="back-to-top" aria-label="Back to top">↑</button>
+<script type="module" src="assets/js/main.js"></script>
 </body>
 </html>

--- a/public/terms.html
+++ b/public/terms.html
@@ -486,5 +486,7 @@
     });
 </script>
 
+<button id="back-to-top" aria-label="Back to top">↑</button>
+<script type="module" src="assets/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `assets/js/main.js` with smooth scroll and back-to-top helpers
- style the back-to-top button
- include the new script and button across site pages
- remove old inline smooth-scroll code

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6875da3d61a083278dfa28c5e57e0476