### PR TITLE
Add frosted glass navigation sample

### DIFF
--- a/public/frosted-nav.html
+++ b/public/frosted-nav.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Frosted Glass Gooey Gravity Nav</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: system-ui, sans-serif;
+      background: linear-gradient(45deg,#0f172a,#334155);
+      color: #fff;
+      min-height: 100vh;
+      display:flex;
+      justify-content:center;
+      align-items:center;
+      text-align:center;
+    }
+    nav ul {
+      list-style:none;
+      display:flex;
+      gap:2rem;
+      background:rgba(255,255,255,0.1);
+      padding:1rem 2rem;
+      border-radius:9999px;
+      backdrop-filter:blur(10px);
+      position:relative;
+    }
+    nav a {
+      color:#fff;
+      text-decoration:none;
+      text-transform:uppercase;
+      font-weight:600;
+      padding:.5rem 1rem;
+    }
+    .effect.filter {
+      position:absolute;
+      top:0;
+      left:0;
+      width:80px;
+      height:40px;
+      background:rgba(255,255,255,0.25);
+      border-radius:9999px;
+      pointer-events:none;
+      transform:translate(-50%,-50%);
+    }
+    .effect.text {
+      position:absolute;
+      pointer-events:none;
+      font-size:.75rem;
+      text-transform:uppercase;
+      left:50%;
+      transform:translateX(-50%);
+      top:-1.5rem;
+    }
+    .social-icon {
+      position:fixed;
+      bottom:1rem;
+      right:1rem;
+      color:#fff;
+      text-decoration:none;
+      font-size:.875rem;
+    }
+    .social-icon + .social-icon { margin-left:.5rem; }
+    .social-icon svg { width:24px; height:24px; fill:currentColor; }
+  </style>
+</head>
+<body>
+<main id="app">
+  <h1>Frosted Glass Gooey Gravity Nav</h1>
+  <nav>
+    <ul>
+      <li><a href="#">home</a></li>
+      <li><a href="#">about</a></li>
+      <li><a href="#">feature</a></li>
+    </ul>
+  </nav>
+  <span class="effect filter"></span>
+  <span class="effect text">home</span>
+</main>
+<a class="social-icon codepen" href="https://codepen.io/simeydotme" title="view my codepens">Made by Simey</a>
+<a class="social-icon twitter" href="https://twitter.com/simeydotme">
+  <svg viewBox="0 0 24 24">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+    <path d="M22 4.01c-1 .49 -1.98 .689 -3 .99c-1.121 -1.265 -2.783 -1.335 -4.38 -.737s-2.643 2.06 -2.62 3.737v1c-3.245 .083 -6.135 -1.395 -8 -4c0 0 -4.182 7.433 4 11c-1.872 1.247 -3.739 2.088 -6 2c3.308 1.803 6.913 2.423 10.034 1.517c3.58 -1.04 6.522 -3.723 7.651 -7.742a13.84 13.84 0 0 0 .497 -3.753c-.002 -.249 1.51 -2.772 1.818 -4.013z"></path>
+  </svg>
+</a>
+<a class="social-icon github" href="https://github.com/simeydotme">
+  <svg viewBox="0 0 24 24">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+    <path d="M9 19c-4.3 1.4 -4.3 -2.5 -6 -3m12 5v-3.5c0 -1 .1 -1.4 -.5 -2c2.8 -.3 5.5 -1.4 5.5 -6a4.6 4.6 0 0 0 -1.3 -3.2a4.2 4.2 0 0 0 -.1 -3.2s-1.1 -.3 -3.5 1.3a12.3 12.3 0 0 0 -6.2 0c-2.4 -1.6 -3.5 -1.3 -3.5 -1.3a4.2 4.2 0 0 0 -.1 3.2a4.6 4.6 0 0 0 -1.3 3.2c0 4.6 2.7 5.7 5.5 6c-.6 .6 -.6 1.2 -.5 2v3.5"></path>
+  </svg>
+</a>
+<script>
+  const nav = document.querySelector('nav');
+  const filter = document.querySelector('.effect.filter');
+  const text = document.querySelector('.effect.text');
+  nav.addEventListener('mousemove', e => {
+    const link = e.target.closest('a');
+    if(!link) return;
+    const rect = link.getBoundingClientRect();
+    const navRect = nav.getBoundingClientRect();
+    filter.style.transform = `translate(${rect.left - navRect.left + rect.width/2}px,${rect.top - navRect.top + rect.height/2}px)`;
+    filter.style.width = `${rect.width}px`;
+    filter.style.height = `${rect.height}px`;
+    text.textContent = link.textContent;
+    text.style.left = `${rect.left - navRect.left + rect.width/2}px`;
+    text.style.top = `${rect.top - navRect.top - 10}px`;
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new `frosted-nav.html` file under `public/` that demonstrates a frosted glass navigation bar with social icons

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6876fd849ff08327b41a3287e558ef61