### PR TITLE
Fix Terms nav link

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,9 +161,7 @@
                 <button class="nav-link" data-section="contact">Contact</button>
               </li>
               <li class="nav-item">
-                                <button
-                  class="nav-link"
-                  onclick="window.open('/pages/terms.html')">Terms</button>
+                <a class="nav-link" href="/pages/terms.html">Terms</a>
               </li>
             </ul>
 
@@ -209,12 +207,7 @@
             <button class="mobile-nav-link" data-section="contact">
               Contact
             </button>
-            <button
-              class="mobile-nav-link"
-              onclick="window.open('/pages/terms.html', '_blank')"
-            >
-              Terms
-            </button>
+            <a class="mobile-nav-link" href="/pages/terms.html">Terms</a>
             <div class="mobile-cta">
               <button
                 class="glass-button primary w-full"


### PR DESCRIPTION
## Summary
- make Terms link an anchor to pages/terms.html
- update mobile menu Terms link

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687be7329ba88327b23994dbf65039e6

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Convert the "Terms" navigation link from a button element with a window.open JavaScript call to a standard anchor (`<a>`) element in both desktop and mobile navigation menus.

### Why are these changes being made?
The change simplifies the codebase and improves accessibility by using semantic HTML. It also enhances user experience by making the "Terms" link consistent with other navigation links that use standard anchor elements, ensuring better support for assistive technologies and aligning with best practices.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->