### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-grunt.yml
+++ b/.github/workflows/npm-grunt.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Icantcode45/cashforyourhome.biz/security/code-scanning/4](https://github.com/Icantcode45/cashforyourhome.biz/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will restrict the permissions granted to the `GITHUB_TOKEN` to the minimum required for the workflow. Based on the provided steps, the workflow primarily checks out code and installs dependencies, so it only needs `contents: read` permission. If additional permissions (e.g., `issues: write`, `pull-requests: write`) are needed for future steps, they can be added later.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
