### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jekyll-docker.yml
+++ b/.github/workflows/jekyll-docker.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Jekyll site CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Icantcode45/cashforyourhome.biz/security/code-scanning/3](https://github.com/Icantcode45/cashforyourhome.biz/security/code-scanning/3)

To fix the problem, you should add an explicit `permissions` block to the workflow to restrict the GITHUB_TOKEN to the minimal set needed. In this case, the workflow only checks out code and builds the site; it does not push changes, create releases, or interact with issues or pull requests. Therefore, the minimal permission required is `contents: read`. The best way to implement this is to add the following block near the top of the workflow, after the `name` and before the `on` key, so that it applies to the entire workflow unless overridden in individual jobs.

No imports or additional definitions are needed, just a one-line addition to the YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add permissions settings to the `jekyll-docker.yml` GitHub Actions workflow by specifying `contents: read`.

### Why are these changes being made?

This change addresses a code scanning alert by ensuring explicit permission is granted for reading contents in the workflow, thereby following best practices for security and maintaining clear, well-defined permissions in the continuous integration and deployment process.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->