### PR TITLE
Add Dockerfile with image description label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:alpine
+COPY . /usr/share/nginx/html
+LABEL org.opencontainers.image.description="Static site for Cash for Your Home"


### PR DESCRIPTION
## Summary
- add a simple Dockerfile to serve the static site via nginx
- include an `org.opencontainers.image.description` label to describe the image

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e9078bb308327aecbc60d610dd501


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
