### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/appknox.yml
+++ b/.github/workflows/appknox.yml
@@ -21,6 +21,10 @@
 
 name: Appknox
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Icantcode45/cashforyourhome.biz/security/code-scanning/6](https://github.com/Icantcode45/cashforyourhome.biz/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily needs read access to the repository contents and write access to upload SARIF files to GitHub Advanced Security (GHAS). Therefore, we will set `contents: read` and `security-events: write` in the `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add permissions for contents to read and security-events to write in the .github/workflows/appknox.yml file.

### Why are these changes being made?

These changes address a code scanning alert regarding missing permissions in the workflow, ensuring the workflow functions correctly with the necessary access levels while maintaining security compliance. This is the optimal approach as it specifically grants only the required permissions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
