### PR TITLE
Potential fix for code scanning alert no. 70: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Icantcode45/cashforyourhome.biz/security/code-scanning/70](https://github.com/Icantcode45/cashforyourhome.biz/security/code-scanning/70)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the workflow only checks out code, installs dependencies, builds, and runs tests, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow file (just after the `name:` key and before `on:`), so it applies to all jobs in the workflow. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
